### PR TITLE
fixed path glob separator on Windows (packages-list)

### DIFF
--- a/tools/packages-list/src/lib/lib/glob-packages.ts
+++ b/tools/packages-list/src/lib/lib/glob-packages.ts
@@ -16,7 +16,7 @@ export const globPackages = async ({
     const globs = Array.isArray(dirGlobs) ? dirGlobs : [dirGlobs];
 
     const packagePaths = await globby(
-        globs.map(dirGlob => Path.join(dirGlob, 'package.json')),
+        globs.map(dirGlob => Path.join(dirGlob, 'package.json').replace(/\\/g, '/')),
         { cwd: rootPath }
     );
 


### PR DESCRIPTION
globby requires the use of forward slashes as path separators and on Windows OS Path.join will use backslashes in creating the path. This change replaces backslashes to forward slashes to fix globby results for Windows. More info https://github.com/sindresorhus/globby/issues/179